### PR TITLE
Add the ability to use a pre-registered api key on client creation

### DIFF
--- a/src/QStash.php
+++ b/src/QStash.php
@@ -7,10 +7,17 @@ use Psr\Clock\ClockInterface;
 
 class QStash
 {
-    public static function client(string $apiKey): Client
+    private static $apiKey;
+
+    public static function key(string $apiKey)
+    {
+        self::$apiKey = $apiKey;
+    }
+
+    public static function client(?string $apiKey = null): Client
     {
         return self::factory()
-            ->withApiKey($apiKey)
+            ->withApiKey($apiKey ?? self::$apiKey)
             ->withBaseUrl('https://qstash.upstash.io/v2/')
             ->make();
     }

--- a/tests/Expectations.php
+++ b/tests/Expectations.php
@@ -1,0 +1,13 @@
+<?php
+
+use PHPUnit\Framework\Assert;
+
+expect()->extend('toUseApiKey', function (string $apiKey) {
+    $transporterProperty = new \ReflectionProperty($this->value, 'transporter');
+    $transporter = $transporterProperty->getValue($this->value);
+    $headerProperty = new \ReflectionProperty($transporter, 'headers');
+    $headersWrapper = $headerProperty->getValue($transporter);
+    $headers = $headersWrapper->toArray();
+    Assert::assertArrayHasKey('Authorization', $headers);
+    Assert::assertEquals($headers['Authorization'], 'Bearer '.$apiKey);
+});

--- a/tests/QStashTest.php
+++ b/tests/QStashTest.php
@@ -4,10 +4,34 @@ use HeyJorgeDev\QStash\Client;
 use HeyJorgeDev\QStash\Factory;
 use HeyJorgeDev\QStash\QStash;
 
-it('returns an instance of client', function () {
-    $client = QStash::client('some-api-key');
+it('returns an instance of client using the given api key', function () {
+    $key = 'some-api-key';
+    $client = QStash::client($key);
 
-    expect($client)->toBeInstanceOf(Client::class);
+    expect($client)
+        ->toBeInstanceOf(Client::class)
+        ->toUseApiKey($key);
+});
+
+it('returns an instance of client using the pre-configured api key', function () {
+    $key = 'some-api-key';
+    QStash::key($key);
+    $client = QStash::client();
+
+    expect($client)
+        ->toBeInstanceOf(Client::class)
+        ->toUseApiKey($key);
+});
+
+it('returns an instance of client using the given key even with a pre-configured api key', function () {
+    $key = 'some-api-key';
+    QStash::key($key);
+    $instanceKey = 'some-other-api-key';
+    $client = QStash::client($instanceKey);
+
+    expect($client)
+        ->toBeInstanceOf(Client::class)
+        ->toUseApiKey($instanceKey);
 });
 
 it('returns an instance of factory', function () {


### PR DESCRIPTION
Currently, the client creation requires an API KEY value as parameter,

If you are not using a factory method the shield you of constantly consume this sensitive information, you will have the need to provide this sensitive information to all the sections of the code that instantiate a client.

To prevent this, this PR implements the ability to pre-register an API KEY in the QStash factory facade so you can just request the client creation without constantly provide the said API KEY.